### PR TITLE
Fix bug: get GitHub Username instead of Name

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -35,7 +35,7 @@ Route::get('/auth/callback', function () {
     $user = User::updateOrCreate([
         'github_id' => $githubUser->id,
     ], [
-        'github_username' => $githubUser->name,
+        'github_username' => $githubUser->nickname,
         'github_access_token' => $githubUser->token,
         'github_refresh_token' => $githubUser->refreshToken,
     ]);


### PR DESCRIPTION
Solved issue: if user has no Name, an SQL error was thrown. Changed to Username, as it's compulsory an unique on Github